### PR TITLE
Check for missing files before moving any file

### DIFF
--- a/MarkdownLinkedImagesMover.Tests/AppTests.cs
+++ b/MarkdownLinkedImagesMover.Tests/AppTests.cs
@@ -9,7 +9,31 @@ namespace MarkdownLinkedImagesMover.Tests;
 public sealed class AppTests
 {
     [Fact]
-    public void ProcessTestfile()
+    public void GivenLastImageDoesNotExist_DoesNotMoveAnyFile()
+    {
+        const string sourceFileFullName = "/MockedSourceFile.md";
+        var fileSystemMock = new MockFileSystem(
+            new Dictionary<string, MockFileData>
+            {
+                { sourceFileFullName, new MockFileData("![[image1.png]] ![[image2.png]]") },
+                { "/image1.png", new MockFileData("") }
+            }
+        );
+
+        Assert.False(fileSystemMock.FileExists("/image.png"));
+
+        var targetDir = new DirectoryInfo("/MockedTargetDir");
+        var sourceFile = new FileInfo(sourceFileFullName);
+        var loggerMock = new Mock<ILogger<App>>();
+        var fileMoverMock = new Mock<IFileMover>();
+        new App(loggerMock.Object, fileSystemMock, fileMoverMock.Object).Run(sourceFile, targetDir);
+
+// TODO: Verify that an error has been reported in a separate test - loggerMock.VerifyLog(logger => logger.LogError("File '{@ImageFile}' does not exist", "/image.png"));
+        fileMoverMock.Verify(mover => mover.Move(It.IsAny<FileInfo>(), It.IsAny<DirectoryInfo>()), Times.Never);
+    }
+
+    [Fact]
+    public void GivenAllImagesExist_ProducesCorrectLogs()
     {
         const string sourceFileFullName = "/MockedSourceFile.md";
         var targetDir = new DirectoryInfo("/MockedTargetDir");

--- a/MarkdownLinkedImagesMover.Tests/AppTests.cs
+++ b/MarkdownLinkedImagesMover.Tests/AppTests.cs
@@ -9,7 +9,7 @@ namespace MarkdownLinkedImagesMover.Tests;
 public sealed class AppTests
 {
     [Fact]
-    public void GivenLastImageDoesNotExist_DoesNotMoveAnyFile()
+    public void WhenLastImageDoesNotExist_ThenDoNotMoveAnyFile()
     {
         const string sourceFileFullName = "/MockedSourceFile.md";
         var fileSystemMock = new MockFileSystem(
@@ -30,12 +30,36 @@ public sealed class AppTests
 
         new App(loggerMock.Object, fileSystemMock, fileMoverMock.Object).Run(sourceFile, targetDir);
 
-// TODO: Verify that an error has been reported in a separate test - loggerMock.VerifyLog(logger => logger.LogError("File '{@ImageFile}' does not exist", "/image.png"));
         fileMoverMock.Verify(mover => mover.Move(It.IsAny<FileInfo>(), It.IsAny<DirectoryInfo>()), Times.Never);
     }
 
     [Fact]
-    public void GivenAllImagesExist_ProducesCorrectLogs()
+    public void WhenImagesDoNotExist_ThenLogMissingFiles()
+    {
+        const string sourceFileFullName = "/MockedSourceFile.md";
+        var fileSystemMock = new MockFileSystem(
+            new Dictionary<string, MockFileData>
+            {
+                { sourceFileFullName, new MockFileData("![[image1.png]] ![[image2.png]] ![[image3.png]]") },
+                // /image1.png does not exist
+                { "/image2.png", new MockFileData("") }
+                // /image3.png does not exist
+            }
+        );
+
+        var targetDir = new DirectoryInfo("/MockedTargetDir");
+        var sourceFile = new FileInfo(sourceFileFullName);
+        var loggerMock = new Mock<ILogger<App>>();
+        var fileMoverMock = new Mock<IFileMover>();
+
+        new App(loggerMock.Object, fileSystemMock, fileMoverMock.Object).Run(sourceFile, targetDir);
+
+        loggerMock.VerifyLog(logger => logger.LogError("File '{@ImageFile}' does not exist", "/image1.png"));
+        loggerMock.VerifyLog(logger => logger.LogError("File '{@ImageFile}' does not exist", "/image3.png"));
+    }
+
+    [Fact]
+    public void WhenAllImagesExist_ThenProduceCorrectLogs()
     {
         const string sourceFileFullName = "/MockedSourceFile.md";
         var fileSystemMock = new MockFileSystem(

--- a/MarkdownLinkedImagesMover.Tests/AppTests.cs
+++ b/MarkdownLinkedImagesMover.Tests/AppTests.cs
@@ -8,7 +8,6 @@ namespace MarkdownLinkedImagesMover.Tests;
 
 public sealed class AppTests
 {
-    // TODO: BUG: Test what happens if a file contains two images in the same line!
     [Fact]
     public void ProcessTestfile()
     {

--- a/MarkdownLinkedImagesMover.Tests/AppTests.cs
+++ b/MarkdownLinkedImagesMover.Tests/AppTests.cs
@@ -17,6 +17,7 @@ public sealed class AppTests
             {
                 { sourceFileFullName, new MockFileData("![[image1.png]] ![[image2.png]]") },
                 { "/image1.png", new MockFileData("") }
+                // /image2.png does not exist
             }
         );
 
@@ -26,6 +27,7 @@ public sealed class AppTests
         var sourceFile = new FileInfo(sourceFileFullName);
         var loggerMock = new Mock<ILogger<App>>();
         var fileMoverMock = new Mock<IFileMover>();
+
         new App(loggerMock.Object, fileSystemMock, fileMoverMock.Object).Run(sourceFile, targetDir);
 
 // TODO: Verify that an error has been reported in a separate test - loggerMock.VerifyLog(logger => logger.LogError("File '{@ImageFile}' does not exist", "/image.png"));
@@ -36,11 +38,6 @@ public sealed class AppTests
     public void GivenAllImagesExist_ProducesCorrectLogs()
     {
         const string sourceFileFullName = "/MockedSourceFile.md";
-        var targetDir = new DirectoryInfo("/MockedTargetDir");
-
-        var loggerMock = new Mock<ILogger<App>>();
-
-        var sourceFile = new FileInfo(sourceFileFullName);
         var fileSystemMock = new MockFileSystem(
             new Dictionary<string, MockFileData>
             {
@@ -48,7 +45,12 @@ public sealed class AppTests
             }
         );
 
-        new App(loggerMock.Object, fileSystemMock, Mock.Of<IFileMover>()).Run(sourceFile, targetDir);
+        var targetDir = new DirectoryInfo("/MockedTargetDir");
+        var sourceFile = new FileInfo(sourceFileFullName);
+        var loggerMock = new Mock<ILogger<App>>();
+        var fileMoverMock = new Mock<IFileMover>();
+
+        new App(loggerMock.Object, fileSystemMock, fileMoverMock.Object).Run(sourceFile, targetDir);
 
         loggerMock.VerifyLog(logger => logger.LogInformation("Target folder: '{@TargetFolder}'", targetDir.FullName));
         loggerMock.VerifyLog(logger => logger.LogInformation("File '{@SourceFile}' contains", sourceFile.FullName));

--- a/MarkdownLinkedImagesMover/App.cs
+++ b/MarkdownLinkedImagesMover/App.cs
@@ -22,8 +22,15 @@ internal class App
     public void Run(FileInfo markdownFile, DirectoryInfo targetDir)
     {
         var imageNames = GetImagesFromMarkdownFile(markdownFile);
+
         LogImageNames(markdownFile, targetDir, imageNames);
-        MoveImagesToTargetDir(markdownFile, targetDir, imageNames);
+
+        var allImagesExist = ValidateAllFilesExist(markdownFile, imageNames);
+
+        if (allImagesExist)
+        {
+            MoveImagesToTargetDir(markdownFile, targetDir, imageNames);
+        }
     }
 
     private List<string> GetImagesFromMarkdownFile(FileSystemInfo markdownFile)
@@ -38,6 +45,10 @@ internal class App
         _logger.LogInformation("File '{@SourceFile}' contains", markdownFile.FullName);
         imageNames.ForEach(imageName => _logger.LogInformation("- '{@ImageFile}'", imageName));
     }
+
+    private bool ValidateAllFilesExist(FileInfo markdownFile, List<string> imageNames) =>
+        imageNames.Select(imageName => Path.Combine(markdownFile.DirectoryName ?? "", imageName))
+            .All(name => _fileSystem.File.Exists(name));
 
     private void MoveImagesToTargetDir(
         FileInfo markdownFile,


### PR DESCRIPTION
This feature separates the validation step from the actual move file operation.

As a consequence, no file is moved if any file linked in the markdown file is missing.
This makes sure that we do not end up in an intermediate state with half the files
moved and the other half at their original place.