### PR TITLE
fix: code-sign and notarize x86 version

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Sign application
         run: |
-          /bin/sh BuildAndReleaseScripts/SignMac.sh "${{ env.PUBLISH_DIR }}/MarkdownLinkedImagesMover" "${{ env.PUBLISH_DIR }}" "Developer ID Application: Stefan Boos" "BuildAndReleaseScripts/entitlements.plist"
+          /bin/sh BuildAndReleaseScripts/SignMac.sh "${{ env.PUBLISH_DIR }}/MarkdownLinkedImagesMover" "Developer ID Application: Stefan Boos" "BuildAndReleaseScripts/entitlements.plist"
 
       - name: Zip application
         run: |

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -58,7 +58,7 @@ jobs:
     
     strategy:
       matrix:
-        architecture: [arm64, x64]
+        architecture: [arm64]
 
     env:
       RUNTIME: osx.12-${{ matrix.architecture }}
@@ -77,6 +77,11 @@ jobs:
         with:
           dotnet-version: 7.0.x
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true
+          
       - name: Create application
         run: |
           dotnet publish MarkdownLinkedImagesMover/MarkdownLinkedImagesMover.csproj --configuration Release --runtime "\"${{ env.RUNTIME }}\"" --self-contained true -p:PublishSingleFile:true --output "${{ env.PUBLISH_DIR }}"

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Create application
         run: |
-          dotnet publish MarkdownLinkedImagesMover/MarkdownLinkedImagesMover.csproj --configuration Release --runtime "${{ env.RUNTIME }}" --self-contained true -p:PublishSingleFile:true --output "${{ env.PUBLISH_DIR }}"
+          dotnet publish MarkdownLinkedImagesMover/MarkdownLinkedImagesMover.csproj --configuration Release --runtime "\"${{ env.RUNTIME }}\"" --self-contained true -p:PublishSingleFile:true --output "${{ env.PUBLISH_DIR }}"
           rm -vf "${{ env.PUBLISH_DIR }}/MarkdownLinkedImagesMover.pdb" "${{ env.PUBLISH_DIR }}/MarkdownLinkedImagesMover.xml"
           chmod +x "${{ env.PUBLISH_DIR }}/MarkdownLinkedImagesMover"
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -58,7 +58,7 @@ jobs:
     
     strategy:
       matrix:
-        architecture: [arm64]
+        architecture: [arm64, x64]
 
     env:
       RUNTIME: osx.12-${{ matrix.architecture }}
@@ -77,11 +77,6 @@ jobs:
         with:
           dotnet-version: 7.0.x
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        with:
-          limit-access-to-actor: true
-          
       - name: Create application
         run: |
           dotnet publish MarkdownLinkedImagesMover/MarkdownLinkedImagesMover.csproj --configuration Release --runtime "${{ env.RUNTIME }}" --self-contained true -p:PublishSingleFile=true --output "${{ env.PUBLISH_DIR }}"

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -77,10 +77,10 @@ jobs:
         with:
           dotnet-version: 7.0.x
 
-      - name: Create publish package
+      - name: Create application
         run: |
-          dotnet publish MarkdownLinkedImagesMover/MarkdownLinkedImagesMover.csproj --configuration Release --runtime "${{ env.RUNTIME }}" --self-contained true --output "${{ env.PUBLISH_DIR }}"
-          rm -f "${{ env.PUBLISH_DIR }}/*.pdb"
+          dotnet publish MarkdownLinkedImagesMover/MarkdownLinkedImagesMover.csproj --configuration Release --runtime "${{ env.RUNTIME }}" --self-contained true -p:PublishSingleFile:true --output "${{ env.PUBLISH_DIR }}"
+          rm -vf "${{ env.PUBLISH_DIR }}/MarkdownLinkedImagesMover.pdb" "${{ env.PUBLISH_DIR }}/MarkdownLinkedImagesMover.xml"
           chmod +x "${{ env.PUBLISH_DIR }}/MarkdownLinkedImagesMover"
 
       - name: Add cert to keychain
@@ -89,39 +89,29 @@ jobs:
           p12-file-base64: ${{ secrets.APPLE_DEVELOPER_ID_APP_CERTIFICATE_BASE64 }}
           p12-password: ${{ secrets.APPLE_DEVELOPER_ID_APP_CERTIFICATE_PASSWORD }}
 
-      - name: Sign publish artifacts
+      - name: Sign application
         run: |
           /bin/sh BuildAndReleaseScripts/SignMac.sh "${{ env.PUBLISH_DIR }}/MarkdownLinkedImagesMover" "${{ env.PUBLISH_DIR }}" "Developer ID Application: Stefan Boos" "BuildAndReleaseScripts/entitlements.plist"
 
-      - name: Zip publish artifacts
+      - name: Zip application
         run: |
           ditto -c --sequesterRsrc -k -V "${{ env.PUBLISH_DIR }}" "${{ env.PUBLISH_ZIP_FILENAME }}"
 
-      - name: Notarize publish artifacts
+      - name: Notarize application
         run: |
           /bin/sh BuildAndReleaseScripts/Notarize.sh "xpdbumm@boos.systems" "${{ secrets.APPLE_ID_APP_SPECIFIC_PASSWORD }}" "M9YN683HBZ" "${{ env.PUBLISH_ZIP_FILENAME }}"
 
-      - name: Calculate SHA256 hash of publish artifacts
-        run: |
-          shasum -a 256 "${{ env.PUBLISH_ZIP_FILENAME }}" > "${{ env.SHA256SUM_FILENAME }}"
-
-      - name: Attach notarize log to publish artifacts
+      - name: Attach notarize log to build artifacts
         uses: actions/upload-artifact@v3
         with:
           name: ${{ env.NOTARIZE_LOG_FILENAME }}
           path: ./notarize_log.json
           
-      - name: Attach application to publish artifacts
+      - name: Attach application to build artifacts
         uses: actions/upload-artifact@v3
         with:
           name: ${{ env.PUBLISH_ZIP_FILENAME }}
           path: ${{ env.PUBLISH_ZIP_FILENAME }}
-
-      - name: Attach SHA256SUM to publish artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ env.SHA256SUM_FILENAME }}
-          path: ${{ env.SHA256SUM_FILENAME }}
 
   release:
     name: Publish
@@ -160,7 +150,7 @@ jobs:
           r="${r//$'\r'/%0D}"                               # Multiline escape sequences for '\r'
           echo "RELEASE_BODY=$r" >> $GITHUB_OUTPUT          # <--- Set environment variable
 
-      - name: Upload publish artifact to release
+      - name: Upload application to release
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -84,7 +84,7 @@ jobs:
           
       - name: Create application
         run: |
-          dotnet publish MarkdownLinkedImagesMover/MarkdownLinkedImagesMover.csproj --configuration Release --runtime "\"${{ env.RUNTIME }}\"" --self-contained true -p:PublishSingleFile:true --output "${{ env.PUBLISH_DIR }}"
+          dotnet publish MarkdownLinkedImagesMover/MarkdownLinkedImagesMover.csproj --configuration Release --runtime "${{ env.RUNTIME }}" --self-contained true -p:PublishSingleFile=true --output "${{ env.PUBLISH_DIR }}"
           rm -vf "${{ env.PUBLISH_DIR }}/MarkdownLinkedImagesMover.pdb" "${{ env.PUBLISH_DIR }}/MarkdownLinkedImagesMover.xml"
           chmod +x "${{ env.PUBLISH_DIR }}/MarkdownLinkedImagesMover"
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -3,10 +3,10 @@ name: .NET
 # Save energy - only build main branch updates
 on:
   push:
-    branches:
-      - main
-    tags:
-      - 'v*'
+#    branches:
+#      - main
+#    tags:
+#      - 'v*'
   pull_request:
     branches:
       - main
@@ -16,8 +16,8 @@ env:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
     name: Build and test
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 
@@ -53,6 +53,9 @@ jobs:
           path: report
 
   publish:
+    name: Publish
+    needs: build-and-test
+    
     strategy:
       matrix:
         architecture: [arm64, x64]
@@ -65,14 +68,6 @@ jobs:
       NOTARIZE_LOG_FILENAME: notarize_log.${{ matrix.architecture }}.json
 
     runs-on: macos-latest
-    name: Publish
-    if: ${{ startsWith(github.ref, 'refs/tags/') }}
-    
-    needs: build-and-test
-    
-    # Configure GITHUB_TOKEN so that it allows uploading to the release
-    permissions:
-      contents: write
     
     steps:
       - uses: actions/checkout@v3
@@ -116,12 +111,43 @@ jobs:
           name: ${{ env.NOTARIZE_LOG_FILENAME }}
           path: ./notarize_log.json
           
+      - name: Attach application to publish artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.PUBLISH_ZIP_FILENAME }}
+          path: ${{ env.PUBLISH_ZIP_FILENAME }}
+
       - name: Attach SHA256SUM to publish artifacts
         uses: actions/upload-artifact@v3
         with:
           name: ${{ env.SHA256SUM_FILENAME }}
           path: ${{ env.SHA256SUM_FILENAME }}
 
+  release:
+    strategy:
+      matrix:
+        architecture: [arm64, x64]
+
+    env:
+      PUBLISH_ZIP_FILENAME: markdown-linked-images-mover.${{ matrix.architecture }}.bottle.zip
+
+    runs-on: ubuntu-latest
+    name: Publish
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    
+    needs: publish
+
+    # Configure GITHUB_TOKEN so that it allows uploading to the release
+    permissions:
+      contents: write
+    
+    steps:
+      - uses: actions/checkout@v3
+    
+      - uses: actions/download-artifact@v3
+        with:
+          name: ${{ env.PUBLISH_ZIP_FILENAME }}
+    
       # Adopted from https://github.com/svenstaro/upload-release-action
       - name: Read CHANGELOG.md and use it as a body of new release
         id: read_release
@@ -133,7 +159,7 @@ jobs:
           r="${r//$'\r'/%0D}"                               # Multiline escape sequences for '\r'
           echo "RELEASE_BODY=$r" >> $GITHUB_OUTPUT          # <--- Set environment variable
 
-      - name: Upload publish artifacts to release
+      - name: Upload publish artifact to release
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -3,10 +3,10 @@ name: .NET
 # Save energy - only build main branch updates
 on:
   push:
-#    branches:
-#      - main
-#    tags:
-#      - 'v*'
+    branches:
+      - main
+    tags:
+      - 'v*'
   pull_request:
     branches:
       - main

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -124,6 +124,9 @@ jobs:
           path: ${{ env.SHA256SUM_FILENAME }}
 
   release:
+    name: Publish
+    needs: publish
+    
     strategy:
       matrix:
         architecture: [arm64, x64]
@@ -132,10 +135,8 @@ jobs:
       PUBLISH_ZIP_FILENAME: markdown-linked-images-mover.${{ matrix.architecture }}.bottle.zip
 
     runs-on: ubuntu-latest
-    name: Publish
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
     
-    needs: publish
 
     # Configure GITHUB_TOKEN so that it allows uploading to the release
     permissions:

--- a/BuildAndReleaseScripts/SignMac.sh
+++ b/BuildAndReleaseScripts/SignMac.sh
@@ -14,14 +14,8 @@ echo "CertName: $3"
 echo "Entitlements: $4"
 echo "======== END INPUTS ========"
 
-for f in $1 "$2"/createdump
+for f in $1 "$2"/createdump "$2"/*{.dll,.dylib}
 do
   echo "Runtime Signing $f"
   codesign --force --verbose --timestamp --sign "$3" "$f" --options=runtime --no-strict --entitlements "$4"
-done
-
-for f in "$2"/*{.dll,.dylib}
-do 
-  echo "Signing $f" 
-  codesign --force --verbose --timestamp --sign "$3" "$f" --no-strict 
 done

--- a/BuildAndReleaseScripts/SignMac.sh
+++ b/BuildAndReleaseScripts/SignMac.sh
@@ -1,21 +1,18 @@
 #!/bin/sh
 # This file is adopted from https://github.com/coding-flamingo/CodeSignConsoleApp/blob/main/BuildAndReleaseScripts/SignMac.sh
 # and from https://www.kenmuse.com/blog/notarizing-dotnet-console-apps-for-macos/ 
-## usage /bin/sh BuildAndReleaseScripts/SignMac.sh "markdown-linked-images-mover/MarkdownLinkedImagesMover" "markdown-linked-images-mover" "Developer ID Application: Stefan Boos" "BuildAndReleaseScripts/entitlements.plist"
-## RunFile $1 "markdown-linked-images-mover/MarkdownLinkedImagesMover"
-## Directory $2 "markdown-linked-images-mover"
-## CertName $3 "Developer ID Application: YOURORG (YOURDEVID)" 
-## Entitlements $4 "BuildAndReleaseScripts/entitlements.plist"
+#
+# usage /bin/sh BuildAndReleaseScripts/SignMac.sh "markdown-linked-images-mover/MarkdownLinkedImagesMover" "Developer ID Application: Stefan Boos" "BuildAndReleaseScripts/entitlements.plist"
+#
+# RunFile      $1 "markdown-linked-images-mover/MarkdownLinkedImagesMover"
+# CertName     $2 "Developer ID Application: YOURORG (YOURDEVID)" 
+# Entitlements $3 "BuildAndReleaseScripts/entitlements.plist"
 
 echo "======== INPUTS ========"
 echo "RunFile: $1"
-echo "Directory: $2"
-echo "CertName: $3"
-echo "Entitlements: $4"
+echo "CertName: $2"
+echo "Entitlements: $3"
 echo "======== END INPUTS ========"
 
-for f in $1 "$2"/createdump "$2"/*{.dll,.dylib}
-do
-  echo "Runtime Signing $f"
-  codesign --force --verbose --timestamp --sign "$3" "$f" --options=runtime --no-strict --entitlements "$4"
-done
+echo "Runtime Signing $1"
+codesign --force --verbose --timestamp --sign "$2" "$1" --options=runtime --no-strict --entitlements "$3"


### PR DESCRIPTION
Code-signing and notarizing worked only for the arm64 version.

For x86 Intel, the DLLs of the .net framework were not accepted by the computer running the application.

The fix was to package the entire application into a self-contained, single file executable