### PR TITLE
fix(ci): fix version reference in nuspec and other chocolatey check warnings

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -19,12 +19,17 @@ on:
 
 env:
   RETENTION_DAYS: 5
+  VERSION: ${GITHUB_REF_NAME#v}
 
 jobs:
   build-and-test:
     name: Build and test
     runs-on: ubuntu-latest
     steps:
+      - name: Display relevant environment variables
+        run: |
+          echo "VERSION=${{ env.VERSION }}"
+
       - uses: actions/checkout@v3
 
       - name: Setup .NET
@@ -87,7 +92,7 @@ jobs:
 
       - name: Create application
         run: |
-          dotnet publish malimo/malimo.csproj --configuration Release --runtime "${{ matrix.runtime }}" --self-contained true -p:PublishSingleFile=true --output "${{ env.PUBLISH_DIR }}"
+          dotnet publish malimo/malimo.csproj --configuration Release --runtime "${{ matrix.runtime }}" --self-contained true -p:PublishSingleFile=true -p:Version=${{ env.VERSION }} --output "${{ env.PUBLISH_DIR }}"
 
       - name: Prepare release files
         run: |
@@ -152,7 +157,7 @@ jobs:
 
       - name: Create application
         run: |
-          dotnet publish malimo/malimo.csproj --configuration Release --runtime "${{ matrix.runtime }}" --self-contained true -p:PublishSingleFile=true --output "${{ env.PUBLISH_DIR }}"
+          dotnet publish malimo/malimo.csproj --configuration Release --runtime "${{ matrix.runtime }}" --self-contained true -p:PublishSingleFile=true -p:Version=${{ env.VERSION }} --output "${{ env.PUBLISH_DIR }}"
 
       - name: ZIP application
         uses: thedoctor0/zip-release@0.7.1
@@ -198,12 +203,8 @@ jobs:
           mv malimo.osx.12-x64.bottle.zip/malimo.osx.12-x64.bottle.zip ./release/
           mv malimo.win-x64.zip/malimo.win-x64.zip ./release/
 
-      - name: Identify Version
-        id: identify_version
-        run: echo "VERSION=${{ github.ref_name }}" | sed 's/=v/=/' >> $GITHUB_OUTPUT
-        
       - name: Prepare Chocolatey configuration
-        run: pwsh ./BuildAndReleaseScripts/ReplaceVariablesInChocolateyConfiguration.ps1 -version ${{ steps.identify_version.outputs.VERSION }} -zipFile ./release/malimo.win-x64.zip
+        run: pwsh ./BuildAndReleaseScripts/ReplaceVariablesInChocolateyConfiguration.ps1 -version ${{ env.VERSION }} -zipFile ./release/malimo.win-x64.zip
 
       - name: Create Chocolatey package
         run: choco pack --outputdirectory ./release ./Chocolatey/malimo.nuspec
@@ -211,7 +212,7 @@ jobs:
       - name: Push Chocolatey package
         run: |
           choco apikey --key ${{ secrets.CHOCO_API_KEY }} --source https://push.chocolatey.org/
-          choco push ./release/malimo.${{ steps.identify_version.outputs.VERSION }}.nupkg --source https://push.chocolatey.org/
+          choco push ./release/malimo.${{ env.VERSION }}.nupkg --source https://push.chocolatey.org/
 
       # Adopted from https://github.com/svenstaro/upload-release-action
       - name: Read CHANGELOG.md and use it as a body of new release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.7-alpha] - 2023-04-10
+
+### Fixed
+
+- Correct download URL for the Chocolatey package
+- Automatically use correct release version number in the published application
+- Correct style issues in the Chocolatey .nuspec file
+
 ## [0.1.6-alpha] - 2023-04-08
 
 ### Added

--- a/Chocolatey/malimo.nuspec
+++ b/Chocolatey/malimo.nuspec
@@ -8,7 +8,8 @@
 
     <title>malimo (Install)</title>
     <authors>Stefan Boos</authors>
-    <projectUrl>https://github.com/wonderbird/malimo</projectUrl>
+    <projectUrl>https://github.com/wonderbird/malimo#readme</projectUrl>
+    <iconUrl>https://cdn.statically.io/gh/wonderbird/malimo/7192c2c7f252eba335cbde99d7b31dc26890a2e7/assets/application-icon/application-icon.png</iconUrl>
     <copyright>2023 Stefan Boos</copyright>
     <licenseUrl>https://raw.githubusercontent.com/wonderbird/malimo/main/LICENSE</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -18,6 +19,7 @@
     <tags>malimo markdown link image move</tags>
     <summary>Markdown Linked Images Mover</summary>
     <description>Move all images used by a markdown file into a folder</description>
+    <releaseNotes>[Markdown Linked Images Mover (malimo) Release Notes](https://github.com/wonderbird/malimo/releases)</releaseNotes>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />

--- a/Chocolatey/tools/chocolateyinstall.ps1
+++ b/Chocolatey/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@
 $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $version = 'Will be replaced by the CI pipeline'
 $hash = 'Will be replaced by the CI pipeline'
-$url64 = 'https://github.com/wonderbird/malimo/releases/download/v$version/malimo.win-x64.zip'
+$url64 = "https://github.com/wonderbird/malimo/releases/download/v$version/malimo.win-x64.zip"
 
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName

--- a/malimo/malimo.csproj
+++ b/malimo/malimo.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net7.0</TargetFramework>
         <OutputType>Exe</OutputType>
         <LangVersion>10</LangVersion>
-        <Version>0.1.5.0</Version>
+        <Version>0.0.0-snapshot</Version>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
malimo failed automated package testing with the following error:

```txt
2023-04-08 23:00:06,557 5116 [ERROR] - ERROR: The remote file either doesn't exist, is unauthorized, or is forbidden for url 'https://github.com/wonderbird/malimo/releases/download/v$version/malimo.win-x64.zip'. Exception calling "GetResponse" with "0" argument(s): "The remote server returned an error: (404) Not Found."
 at Get-WebFile, C:\ProgramData\chocolatey\helpers\functions\Get-WebFile.ps1: line 330
at Get-ChocolateyWebFile, C:\ProgramData\chocolatey\helpers\functions\Get-ChocolateyWebFile.ps1: line 345
at Install-ChocolateyZipPackage, C:\ProgramData\chocolatey\helpers\functions\Install-ChocolateyZipPackage.ps1: line 224
at <ScriptBlock>, C:\ProgramData\chocolatey\lib\malimo\tools\chocolateyinstall.ps1: line 18
at <ScriptBlock>, C:\ProgramData\chocolatey\helpers\chocolateyScriptRunner.ps1: line 59
at <ScriptBlock>, <No file>: line 1
```

In addition, the automatic Chocolatey check showed the following issues:

- [IconUrl Missing](https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0033)
- [ProjectSourceUrl Matches ProjectUrl](https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0041)
- [ReleaseNotes Missing](https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0033)